### PR TITLE
Enhance session badge styling and show count on tab

### DIFF
--- a/client/src/components/css/elder/dashboard.module.css
+++ b/client/src/components/css/elder/dashboard.module.css
@@ -339,17 +339,20 @@
 }
 
 .countBadge {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-  font-size: 0.75rem;
-  font-weight: 600;
-  padding: 2px 6px;
+  background: #3b82f6;
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 2px 8px;
   border-radius: 10px;
   margin-left: 8px;
-  min-width: 20px;
+  min-width: 22px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border: 2px solid #fff;
+  box-shadow: 0 2px 8px rgba(59,130,246,0.15);
+  transition: background 0.2s, color 0.2s;
 }
 
 /* Modern Appointments Grid */

--- a/client/src/pages/elder/dashboard.js
+++ b/client/src/pages/elder/dashboard.js
@@ -884,6 +884,11 @@ const ElderDashboard = () => {
                   onClick={() => setActiveSessionTab("upcoming")}
                 >
                   Upcoming
+                  {statsData.upcomingSessions > 0 && (
+                    <span className={styles.countBadge}>
+                      {statsData.upcomingSessions}
+                    </span>
+                  )}
                 </button>
                 <button
                   className={`${styles.tabBtn} ${


### PR DESCRIPTION
Updated the countBadge CSS for improved appearance and visibility. Added a badge to the 'Upcoming' tab in the elder dashboard to display the number of upcoming sessions when greater than zero.